### PR TITLE
making interface of Onfido::NullLogger compliant with RestClient.log

### DIFF
--- a/lib/onfido/null_logger.rb
+++ b/lib/onfido/null_logger.rb
@@ -1,6 +1,6 @@
 module Onfido
   class NullLogger
-    def <<
+    def <<(*args)
     end
   end
 end


### PR DESCRIPTION
Found (by chance) a test failure depending on test order:

```
bundle exec rspec --seed 57363
```

Turned out that the `NullLogger` was not accepting arguments.
