### PR TITLE
Add support for validating webhooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,22 @@ rescue Onfido::RequestError => e
 end
 ```
 
+## Webhooks
+
+Each webhook endpoint has a secret token, generated automatically and [exposed](https://onfido.com/documentation#register-webhook) in the API. When sending a request, Onfido includes a signature computed using the request body and this token in the `X-Signature` header.
+
+This provided signature [should](https://onfido.com/documentation#webhook-security) be compared to one you generate yourself with the token to check that a webhook is a genuine request from Onfido.
+
+```ruby
+if Onfido::Webhook.valid?(request.raw_post,
+                          request.headers["X-Signature"],
+                          ENV['ONFIDO_WEBHOOK_TOKEN'])
+  process_webhook
+else
+  render status: 498, text: "498 Token expired/invalid"
+end
+```
+
 ## Roadmap
 
 - Improve test coverage with more scenarios

--- a/lib/onfido.rb
+++ b/lib/onfido.rb
@@ -2,6 +2,7 @@ require 'json'
 require 'rack'
 require 'rest-client'
 require 'open-uri'
+require 'openssl'
 
 require 'onfido/version'
 require 'onfido/configuration'

--- a/lib/onfido/resources/webhook.rb
+++ b/lib/onfido/resources/webhook.rb
@@ -14,5 +14,23 @@ module Onfido
     def all(page: 1, per_page: 20)
       get(url: url_for("webhooks?page=#{page}&per_page=#{per_page}"))
     end
+
+    # As well as being a normal resource, Onfido::Webhook also supports
+    # verifying the authenticity of a webhook by comparing the signature on the
+    # request to one computed from the body
+    def self.valid?(request_body, request_signature, token)
+      if [request_body, request_signature, token].any?(&:nil?)
+        raise ArgumentError, "A request body, request signature and token " \
+                             "must be provided"
+      end
+
+      computed_signature = generate_signature(request_body, token)
+      Rack::Utils.secure_compare(request_signature, computed_signature)
+    end
+
+    def self.generate_signature(request_body, token)
+      OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha1'), token, request_body)
+    end
+    private_class_method :generate_signature
   end
 end

--- a/spec/integrations/webhook_spec.rb
+++ b/spec/integrations/webhook_spec.rb
@@ -46,4 +46,46 @@ describe Onfido::Webhook do
       expect(response["webhooks"][1]["id"]).to_not be_nil
     end
   end
+
+  describe ".valid?" do
+    subject(:valid?) do
+      described_class.valid?(request_body, request_signature, token)
+    end
+
+    let(:request_body) { '{"foo":"bar"}' }
+    let(:request_signature) { 'fdab9db604d33297741b43b9fc9536028d09dca3' }
+    let(:token) { 'very_secret_token' }
+
+    it { is_expected.to be(true) }
+
+    context "with an invalid signature" do
+      let(:request_signature) { '2f3d7727ff9a32a7c87072ce514df1f6d3228bec' }
+      it { is_expected.to be(false) }
+    end
+
+    context "with a nil request signature" do
+      let(:request_signature) { nil }
+      specify { expect { valid? }.to raise_error(ArgumentError) }
+    end
+
+    context "with a token other than the one used to sign the request" do
+      let(:token) { "quite_secret_token" }
+      it { is_expected.to be(false) }
+    end
+
+    context "with a nil token" do
+      let(:token) { nil }
+      specify { expect { valid? }.to raise_error(ArgumentError) }
+    end
+
+    context "with a modified request body" do
+      let(:request_body) { '{"bar":"baz"}' }
+      it { is_expected.to be(false) }
+    end
+
+    context "with a nil request body" do
+      let(:request_body) { nil }
+      specify { expect { valid? }.to raise_error(ArgumentError) }
+    end
+  end
 end


### PR DESCRIPTION
Each webhook endpoint has a secret token, generated automatically and [exposed](https://onfido.com/documentation#register-webhook) in the API. When sending a request, Onfido includes a signature computed using the request body and this token in the `X-Signature` header.

This provided signature [should](https://onfido.com/documentation#webhook-security) be compared to one you generate yourself with the token to check that a webhook is a genuine request from Onfido.

This adds functionality to the library, as a class method of Onfido::Webhook (`.valid?`) which allows webhooks to be validated.