### PR TITLE
Permit an "expand" option when accessing the Checks API

### DIFF
--- a/lib/onfido/resources/check.rb
+++ b/lib/onfido/resources/check.rb
@@ -7,12 +7,15 @@ module Onfido
       )
     end
 
-    def find(applicant_id, check_id)
-      get(url: url_for("applicants/#{applicant_id}/checks/#{check_id}"))
+    def find(applicant_id, check_id, expand: nil)
+      querystring = "&expand=#{expand}" if expand
+      get(url: url_for("applicants/#{applicant_id}/checks/#{check_id}?" \
+                       "#{querystring}"))
     end
 
-    def all(applicant_id, page: 1, per_page: 20)
+    def all(applicant_id, page: 1, per_page: 20, expand: nil)
       querystring = "page=#{page}&per_page=#{per_page}"
+      querystring += "&expand=#{expand}" if expand
       get(url: url_for("applicants/#{applicant_id}/checks?#{querystring}"))
     end
   end

--- a/spec/integrations/check_spec.rb
+++ b/spec/integrations/check_spec.rb
@@ -18,6 +18,16 @@ describe Onfido::Check do
       response = check.find(applicant_id, check_id)
       expect(response['id']).to eq(check_id)
     end
+
+    it "returns unexpanded reports" do
+      response = check.find(applicant_id, check_id)
+      expect(response['reports'].first).to be_a(String)
+    end
+
+    it 'allows you to expand the reports' do
+      response = check.find(applicant_id, check_id, expand: "reports")
+      expect(response['reports'].first).to be_a(Hash)
+    end
   end
 
   describe '#all' do
@@ -28,6 +38,16 @@ describe Onfido::Check do
         response = check.all(applicant_id)
         expect(response['checks'].size).to eq(1)
       end
+    end
+
+    it "returns unexpanded reports" do
+      response = check.all(applicant_id)
+      expect(response['checks'].first['reports'].first).to be_a(String)
+    end
+
+    it 'allows you to expand the reports' do
+      response = check.all(applicant_id, expand: "reports")
+      expect(response['checks'].first['reports'].first).to be_a(Hash)
     end
   end
 end

--- a/spec/support/fake_onfido_api.rb
+++ b/spec/support/fake_onfido_api.rb
@@ -31,11 +31,20 @@ class FakeOnfidoAPI < Sinatra::Base
   end
 
   get '/v2/applicants/:id/checks/:id' do
-    json_response(200, 'check.json')
+    if params["expand"] == "reports"
+      json_response(200, "check_with_expanded_reports.json")
+    else
+      json_response(200, "check.json")
+    end
   end
 
   get '/v2/applicants/:id/checks' do
-    response = json_response(200, 'checks.json')
+    response = if params["expand"] == "reports"
+                 json_response(200, "checks_with_expanded_reports.json")
+               else
+                 json_response(200, "checks.json")
+               end
+
     { checks: JSON.parse(response)['checks'][pagination_range] }.to_json
   end
 

--- a/spec/support/fixtures/check.json
+++ b/spec/support/fixtures/check.json
@@ -6,25 +6,7 @@
   "status": "pending",
   "result": "pending",
   "reports": [
-    {
-      "id": "6951786-123123-422221",
-      "name": "identity",
-      "created_at": "2014-05-23T13:50:33Z",
-      "status": "awaiting_applicant",
-      "result": "pending",
-      "href": "/v2/checks/8546921-123123-123123/reports/6951786-123123-422221",
-      "breakdown": {},
-      "properties": {}
-    },
-    {
-      "id": "6951786-123123-316712",
-      "name": "document",
-      "created_at": "2014-05-23T13:50:33Z",
-      "status": "awaiting_applicant",
-      "result": "pending",
-      "href": "/v2/checks/8546921-123123-123123/reports/6951786-123123-316712",
-      "breakdown": {},
-      "properties": {}
-    }
+    "1030303-123123-375629",
+    "1030303-123123-456789"
   ]
 }

--- a/spec/support/fixtures/check_with_expanded_reports.json
+++ b/spec/support/fixtures/check_with_expanded_reports.json
@@ -1,0 +1,30 @@
+{
+  "id": "8546921-123123-123123",
+  "created_at": "2014-05-23T13:50:33Z",
+  "href": "/v2/applicants/61f659cb-c90b-4067-808a-6136b5c01351/checks/8546921-123123-123123",
+  "type": "standard",
+  "status": "pending",
+  "result": "pending",
+  "reports": [
+    {
+      "id": "6951786-123123-422221",
+      "name": "identity",
+      "created_at": "2014-05-23T13:50:33Z",
+      "status": "awaiting_applicant",
+      "result": "pending",
+      "href": "/v2/checks/8546921-123123-123123/reports/6951786-123123-422221",
+      "breakdown": {},
+      "properties": {}
+    },
+    {
+      "id": "6951786-123123-316712",
+      "name": "document",
+      "created_at": "2014-05-23T13:50:33Z",
+      "status": "awaiting_applicant",
+      "result": "pending",
+      "href": "/v2/checks/8546921-123123-123123/reports/6951786-123123-316712",
+      "breakdown": {},
+      "properties": {}
+    }
+  ]
+}

--- a/spec/support/fixtures/checks.json
+++ b/spec/support/fixtures/checks.json
@@ -8,26 +8,8 @@
             "status": "pending",
             "result": "pending",
             "reports": [
-                {
-                    "id": "6951786-123123-422221",
-                    "name": "identity",
-                    "created_at": "2014-05-23T13:50:33Z",
-                    "status": "awaiting_applicant",
-                    "result": "pending",
-                    "href": "/v2/checks/8546921-123123-123123/reports/6951786-123123-422221",
-                    "breakdown": {},
-                    "properties": {}
-                },
-                {
-                    "id": "6951786-123123-316712",
-                    "name": "document",
-                    "created_at": "2014-05-23T13:50:33Z",
-                    "status": "awaiting_applicant",
-                    "result": "pending",
-                    "href": "/v2/checks/8546921-123123-123123/reports/6951786-123123-316712",
-                    "breakdown": {},
-                    "properties": {}
-                }
+              "1030303-123123-375629",
+              "1030303-123123-456789"
             ]
         }
     ]

--- a/spec/support/fixtures/checks_with_expanded_reports.json
+++ b/spec/support/fixtures/checks_with_expanded_reports.json
@@ -1,0 +1,34 @@
+{
+    "checks": [
+        {
+            "id": "8546921-123123-123123",
+            "created_at": "2014-05-23T13:50:33Z",
+            "href": "/v2/applicants/61f659cb-c90b-4067-808a-6136b5c01351/checks/8546921-123123-123123",
+            "type": "standard",
+            "status": "pending",
+            "result": "pending",
+            "reports": [
+                {
+                    "id": "6951786-123123-422221",
+                    "name": "identity",
+                    "created_at": "2014-05-23T13:50:33Z",
+                    "status": "awaiting_applicant",
+                    "result": "pending",
+                    "href": "/v2/checks/8546921-123123-123123/reports/6951786-123123-422221",
+                    "breakdown": {},
+                    "properties": {}
+                },
+                {
+                    "id": "6951786-123123-316712",
+                    "name": "document",
+                    "created_at": "2014-05-23T13:50:33Z",
+                    "status": "awaiting_applicant",
+                    "result": "pending",
+                    "href": "/v2/checks/8546921-123123-123123/reports/6951786-123123-316712",
+                    "breakdown": {},
+                    "properties": {}
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
When using the Checks API (<https://onfido.com/documentation#checks>), an `expand` option with the value `"reports"` may be supplied in order to return the full reports attached to checks, rather than just their IDs. This is a general feature of the API (see <https://onfido.com/documentation#expanding>) but at the moment it is only implemented for the GET APIs for checks.

This adds support for this expand option.