### PR TITLE
add optional api_key param to Onfido::API.new, which is then passed to the resource it calls, then included request header if it exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ You can make API calls by using an instance of the `API` class:
 api = Onfido::API.new
 ```
 
+Alternatively, you can set an API key here instead of in the initializer:
+
+```ruby
+api = Onfido::API.new('API_KEY')
+```
+
 ### Resources
 
 All resources share the same interface when making API calls. Use `.create` to create a resource, `.find` to find one, and `.all` to fetch all resources.

--- a/lib/onfido/api.rb
+++ b/lib/onfido/api.rb
@@ -1,8 +1,12 @@
 module Onfido
   class API
+    def initialize(api_key = nil)
+      @api_key = api_key
+    end
+
     def method_missing(method, *args)
       klass = method.to_s.split('_').collect(&:capitalize).join
-      Object.const_get("Onfido::#{klass}").new
+      Object.const_get("Onfido::#{klass}").new(@api_key)
     rescue NameError
       super
     end

--- a/lib/onfido/resource.rb
+++ b/lib/onfido/resource.rb
@@ -2,6 +2,10 @@ module Onfido
   class Resource
     VALID_HTTP_METHODS = %i(get post).freeze
 
+    def initialize(api_key = nil)
+      @api_key = api_key
+    end
+
     def url_for(path)
       Onfido.endpoint + path
     end
@@ -53,7 +57,7 @@ module Onfido
 
     def headers
       {
-        'Authorization' => "Token token=#{Onfido.api_key}",
+        'Authorization' => "Token token=#{@api_key || Onfido.api_key}",
         'Accept' => "application/json"
       }
     end

--- a/lib/onfido/resource.rb
+++ b/lib/onfido/resource.rb
@@ -3,7 +3,7 @@ module Onfido
     VALID_HTTP_METHODS = %i(get post).freeze
 
     def initialize(api_key = nil)
-      @api_key = api_key
+      @api_key = api_key || Onfido.api_key
     end
 
     def url_for(path)
@@ -57,7 +57,7 @@ module Onfido
 
     def headers
       {
-        'Authorization' => "Token token=#{@api_key || Onfido.api_key}",
+        'Authorization' => "Token token=#{@api_key}",
         'Accept' => "application/json"
       }
     end


### PR DESCRIPTION
Issue #15 Using gem with multiple api keys

The idea is to make the gem more friendly for apps that require the use of more than one Onfido API key (e.g. multi-tenanted apps where each client has their own platform and API keys for various integrations)

The API key set in the configuration is still the default, but this allows instantiation of the `Onfido::API` class with an optional API key parameter, which is then passed to the resource when it's called. Then the auth header method will use `@api_key` if present. Otherwise, it will default to `Onfido.api_key`.