### PR TITLE
Allow for dynamic API keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ You can make API calls by using an instance of the `API` class:
 api = Onfido::API.new
 ```
 
+Alternatively, you can set an API key here instead of in the initializer:
+
+```ruby
+api = Onfido::API.new('API_KEY')
+```
+
 ### Resources
 
 All resources share the same interface when making API calls. Use `.create` to create a resource, `.find` to find one, and `.all` to fetch all resources.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ api = Onfido::API.new
 Alternatively, you can set an API key here instead of in the initializer:
 
 ```ruby
-api = Onfido::API.new('API_KEY')
+api = Onfido::API.new(api_key: 'API_KEY')
 ```
 
 ### Resources

--- a/lib/onfido/api.rb
+++ b/lib/onfido/api.rb
@@ -1,7 +1,7 @@
 module Onfido
   class API
-    def initialize(api_key = nil)
-      @api_key = api_key
+    def initialize(options = {})
+      @api_key = options[:api_key]
     end
 
     def method_missing(method, *args)

--- a/lib/onfido/api.rb
+++ b/lib/onfido/api.rb
@@ -1,8 +1,12 @@
 module Onfido
   class API
+    def initialize(api_key = nil)
+      @api_key = api_key
+    end
+
     def method_missing(method, *args)
       klass = method.to_s.split('_').collect(&:capitalize).join
-      Object.const_get("Onfido::#{klass}").new
+      Object.const_get("Onfido::#{klass}").new(@api_key)
     rescue NameError
       super
     end

--- a/lib/onfido/resource.rb
+++ b/lib/onfido/resource.rb
@@ -2,6 +2,10 @@ module Onfido
   class Resource
     VALID_HTTP_METHODS = %i(get post).freeze
 
+    def initialize(api_key = nil)
+      @api_key = api_key
+    end
+
     def url_for(path)
       Onfido.endpoint + path
     end
@@ -53,7 +57,7 @@ module Onfido
 
     def headers
       {
-        'Authorization' => "Token token=#{Onfido.api_key}",
+        'Authorization' => "Token token=#{@api_key || Onfido.api_key}",
         'Accept' => "application/json"
       }
     end

--- a/lib/onfido/resource.rb
+++ b/lib/onfido/resource.rb
@@ -3,7 +3,7 @@ module Onfido
     VALID_HTTP_METHODS = %i(get post).freeze
 
     def initialize(api_key = nil)
-      @api_key = api_key
+      @api_key = api_key || Onfido.api_key
     end
 
     def url_for(path)
@@ -57,7 +57,7 @@ module Onfido
 
     def headers
       {
-        'Authorization' => "Token token=#{@api_key || Onfido.api_key}",
+        'Authorization' => "Token token=#{@api_key}",
         'Accept' => "application/json"
       }
     end

--- a/spec/onfido/api_spec.rb
+++ b/spec/onfido/api_spec.rb
@@ -12,4 +12,22 @@ describe Onfido::API do
   describe 'given an unknown resource' do
     specify { expect { api.blood_test }.to raise_error(NameError) }
   end
+
+  describe 'given no API key' do
+    it 'uses nil for the resource API key' do
+      expect(Onfido::Address).to receive(:new).with(nil)
+      api.address
+    end
+  end
+
+  describe 'given an API key' do
+    let(:api_key) { 'some_key' }
+
+    subject(:api) { described_class.new(api_key: api_key) }
+
+    it 'uses that key to create the resource' do
+      expect(Onfido::Address).to receive(:new).with(api_key)
+      api.address
+    end
+  end
 end

--- a/spec/onfido/resource_spec.rb
+++ b/spec/onfido/resource_spec.rb
@@ -1,8 +1,24 @@
 describe Onfido::Resource do
   subject(:resource) { described_class.new }
+
   let(:endpoint) { 'https://api.onfido.com/v2/' }
-  let(:path) { 'addresses/pick' }
-  let(:api_key) { 'some_key' }
+  let(:path)     { 'addresses/pick' }
+  let(:url)      { endpoint + path }
+  let(:payload)  { { postcode: 'SE1 4NG' } }
+  let(:api_key)  { 'some_key' }
+
+  let(:response) do
+    {
+      'addresses' => [
+        {
+          'street' => 'Main Street',
+          'town' => 'London',
+          'postcode' => 'SW4 6EH',
+          'country' => 'GBR'
+        }
+      ]
+    }
+  end
 
   before { allow(Onfido).to receive(:endpoint).and_return(endpoint) }
   before { allow(Onfido).to receive(:api_key).and_return(api_key) }
@@ -25,24 +41,54 @@ describe Onfido::Resource do
     end
   end
 
+  describe "API key" do
+    subject(:resource) { described_class.new(specific_api_key) }
+
+    before do
+      expect(RestClient::Request).to receive(:execute).
+        with(
+          url: url,
+          payload: Rack::Utils.build_query(payload),
+          method: :get,
+          headers: resource.send(:headers),
+          open_timeout: 30,
+          timeout: 80
+      ).and_call_original
+
+      WebMock.stub_request(:get, url).
+        to_return(body: response.to_json, status: 200)
+    end
+
+    context "when using a specific key" do
+      let(:specific_api_key) { "specific_key" }
+
+      it "uses that key when making the request" do
+        resource.get(url: url, payload: payload)
+
+        expect(WebMock).to have_requested(:get, url).with(headers: {
+          'Authorization' => "Token token=#{specific_api_key}",
+          'Accept' => "application/json"
+        })
+      end
+    end
+
+    context "when not using a specific key" do
+      let(:specific_api_key) { nil }
+
+      it "uses the general config key when making the request" do
+        resource.get(url: url, payload: payload)
+
+        expect(WebMock).to have_requested(:get, url).with(headers: {
+          'Authorization' => "Token token=#{api_key}",
+          'Accept' => "application/json"
+        })
+      end
+    end
+  end
+
   describe "valid http methods" do
     %i(get post).each do |method|
       context "for supported HTTP method: #{method}" do
-        let(:url) { endpoint + path }
-        let(:payload) { { postcode: 'SE1 4NG' } }
-        let(:response) do
-          {
-            'addresses' => [
-              {
-                'street' => 'Main Street',
-                'town' => 'London',
-                'postcode' => 'SW4 6EH',
-                'country' => 'GBR'
-              }
-            ]
-          }
-        end
-
         before do
           expect(RestClient::Request).to receive(:execute).
             with(


### PR DESCRIPTION
Adds the ability to generate an API client for a specific API key. E.g.:

```ruby
api = Onfido::API.new(api_key: 'some_key')
```

This is based off of the work from @soolaimon, with added tests. The behaviour has been tested using an Onfido account in sandbox mode.

/cc @morganjbruce @RicardoBrazao @greysteil @soolaimon

Closes #15  