### PR TITLE
Fix response content type checking.

### DIFF
--- a/lib/onfido/resource.rb
+++ b/lib/onfido/resource.rb
@@ -52,7 +52,8 @@ module Onfido
     end
 
     def parse(response)
-      if response.headers[:content_type] == "application/json"
+      content_type = response.headers[:content_type]
+      if content_type && content_type.include?("application/json")
         JSON.parse(response.body.to_s)
       else
         response.body

--- a/spec/support/fake_onfido_api.rb
+++ b/spec/support/fake_onfido_api.rb
@@ -127,7 +127,7 @@ class FakeOnfidoAPI < Sinatra::Base
   private
 
   def json_response(response_code, file_name)
-    content_type :json
+    content_type "application/json; charset=utf-8"
     status response_code
     File.open(File.dirname(__FILE__) + '/fixtures/' + file_name, 'rb').read
   end


### PR DESCRIPTION
Usually, Content-Type header is not the exact string but can also contain additional information such as charset encoding.