### PR TITLE
Upgrade rest-client to v2.x

### DIFF
--- a/onfido.gemspec
+++ b/onfido.gemspec
@@ -20,12 +20,12 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '~> 1.7'
   spec.add_development_dependency 'rake', '~> 10.0'
-  spec.add_development_dependency 'webmock', '~> 1.22'
+  spec.add_development_dependency 'webmock', '~> 2.3'
   spec.add_development_dependency 'rubocop', '~> 0.37.0'
   spec.add_development_dependency 'rspec', '~> 3.1'
   spec.add_development_dependency 'rspec-its', '~> 1.2'
   spec.add_development_dependency 'sinatra', '~> 1.4'
 
-  spec.add_dependency 'rest-client', '~> 1.8'
+  spec.add_dependency 'rest-client', '~> 2.0'
   spec.add_dependency 'rack', '~> 1.6'
 end


### PR DESCRIPTION
[rest-client](https://github.com/rest-client/rest-client), which we use for making HTTP requests, was a major version behind, using 1.x rather than the newer 2.x.

Fortunately, [it's an easy upgrade](https://github.com/rest-client/rest-client#upgrading-to-rest-client-20-from-1x), requiring no code changes in our case since the two versions are "largely compatible".

The upgrade also necessitated updating [WebMock](https://github.com/bblimke/webmock) - fortunately [that didn't require any effort](https://github.com/bblimke/webmock/blob/master/CHANGELOG.md#200) either.