### PR TITLE
Remove version dependency on Rack

### DIFF
--- a/onfido.gemspec
+++ b/onfido.gemspec
@@ -27,5 +27,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'sinatra', '~> 1.4'
 
   spec.add_dependency 'rest-client', '~> 2.0'
-  spec.add_dependency 'rack', '~> 1.6'
+  spec.add_dependency 'rack', '>= 1.6.0'
 end


### PR DESCRIPTION
Onfido currently depends on `rack ~> 1.6`, but in order to upgrade to Rails 5 we need `rack ~> 2.0`. 

Removing the explicit rack version dependency should do the trick.