### PR TITLE
Add the sdk_token endpoint

### DIFF
--- a/lib/onfido.rb
+++ b/lib/onfido.rb
@@ -20,6 +20,7 @@ require 'onfido/resources/document'
 require 'onfido/resources/live_photo'
 require 'onfido/resources/report'
 require 'onfido/resources/report_type_group'
+require 'onfido/resources/sdk_token'
 require 'onfido/resources/webhook'
 
 module Onfido

--- a/lib/onfido/resources/sdk_token.rb
+++ b/lib/onfido/resources/sdk_token.rb
@@ -1,5 +1,5 @@
 module Onfido
-  class SDKToken < Resource
+  class SdkToken < Resource
     def create(payload)
       post(
         url: url_for("sdk_token"),

--- a/lib/onfido/resources/sdk_token.rb
+++ b/lib/onfido/resources/sdk_token.rb
@@ -1,0 +1,10 @@
+module Onfido
+  class SDKToken < Resource
+    def create(payload)
+      post(
+        url: url_for("sdk_token"),
+        payload: payload
+      )
+    end
+  end
+end

--- a/spec/integrations/sdk_token_spec.rb
+++ b/spec/integrations/sdk_token_spec.rb
@@ -1,0 +1,14 @@
+describe Onfido::SDKToken do
+  subject(:sdk_token) { described_class.new }
+  let(:applicant_id) { '61f659cb-c90b-4067-808a-6136b5c01351' }
+  let(:referrer) { 'http://*.mywebsite.com/*' }
+
+  describe '#create' do
+    let(:params) { { applicant_id: applicant_id, referrer: referrer } }
+
+    it 'creates a new SDK token for the applicant' do
+      response = sdk_token.create(params)
+      expect(response['token']).not_to be_nil
+    end
+  end
+end

--- a/spec/integrations/sdk_token_spec.rb
+++ b/spec/integrations/sdk_token_spec.rb
@@ -1,4 +1,4 @@
-describe Onfido::SDKToken do
+describe Onfido::SdkToken do
   subject(:sdk_token) { described_class.new }
   let(:applicant_id) { '61f659cb-c90b-4067-808a-6136b5c01351' }
   let(:referrer) { 'http://*.mywebsite.com/*' }

--- a/spec/support/fake_onfido_api.rb
+++ b/spec/support/fake_onfido_api.rb
@@ -98,6 +98,10 @@ class FakeOnfidoAPI < Sinatra::Base
     json_response(200, 'report_type_groups.json')
   end
 
+  post '/v2/sdk_token' do
+    json_response(201, 'sdk_token.json')
+  end
+
   post '/v2/webhooks' do
     json_response(201, 'webhook.json')
   end

--- a/spec/support/fixtures/sdk_token.json
+++ b/spec/support/fixtures/sdk_token.json
@@ -1,0 +1,3 @@
+{
+  "token": "header.payload.signature"
+}


### PR DESCRIPTION
This adds support for generating JSON Web Tokens for use in the JS SDK Onfido supply :)
It's a very simple endpoint so I believe this covers everything required.