### PR TITLE
Add documentation to README for SDK Token creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ api.report.cancel('check_id', 'report_id')
 ```
 
 #### Report Type Groups
+
 Report type groups provide a convenient way to group and organize different types of reports.
  The Onfido API only provides support for finding and listing them.
 
@@ -139,6 +140,15 @@ as through the dashboard.
 api.webhook.create(params)          # => Creates a webhook endpoint
 api.webhook.find('webhook_id')      # => Finds a single webhook endpoint
 api.webhook.all                     # => Returns all webhook endpoints
+```
+
+#### SDK Tokens
+
+Onfido allows you to generate JSON Web Tokens via the API in order to authenticate
+with Onfido's [JavaScript SDK](https://github.com/onfido/onfido-sdk-ui).
+
+```ruby
+api.sdk_token.create(applicant_id: 'applicant_id', referrer: 'referrer')
 ```
 
 ### Pagination


### PR DESCRIPTION
Thanks to @robotmay for adding the code required to create JWT tokens for the Onfido Javascript SDK in #38 - I've added a simple example showing usage instructions to the Readme in a second PR, as the first has already been merged (thanks to @hjheath and @alanjc7!)