### PR TITLE
add latest ruby versions to travis command 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,10 @@ matrix:
     - rvm: rbx-2
 
 rvm:
-  - 2.0
-  - 2.1
   - 2.2
+  - 2.3
+  - 2.4
+  - 2.5
   - jruby
   - rbx-2
 


### PR DESCRIPTION
Added versions - 2.3, 2.4 & 2.5
Removed unsupported versions - 2.0 & 2.1