### PR TITLE
Drop support for creating Documents and Live Photos from a URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,9 @@ api.document.download('applicant_id', 'document_id') # => Downloads a document a
 api.document.all('applicant_id') # => Returns all applicant's documents
 ```
 
-**Note:** The file parameter can be either a `File` object or a link to an image.
+**Note:** The file parameter must be a `File`-like object which responds to `#read` and `#path`.
+Previous versions of this gem supported providing a URL to a file accessible over PHP. You
+should fetch the file yourself and then pass it in to `#create`.
 
 #### Live Photos
 
@@ -83,7 +85,9 @@ They can only be created - the Onfido does not support finding or listing them.
 api.live_photo.create('applicant_id', file: 'http://example.com')
 ```
 
-**Note:** The file parameter can be either a `File` object or a link to an image.
+**Note:** The file parameter must be a `File`-like object which responds to `#read` and `#path`.
+Previous versions of this gem supported providing a URL to a file accessible over PHP. You
+should fetch the file yourself and then pass it in to `#create`.
 
 #### Checks
 

--- a/lib/onfido.rb
+++ b/lib/onfido.rb
@@ -1,7 +1,6 @@
 require 'json'
 require 'rack'
 require 'rest-client'
-require 'open-uri'
 require 'openssl'
 
 require 'onfido/version'

--- a/lib/onfido/resource.rb
+++ b/lib/onfido/resource.rb
@@ -144,5 +144,12 @@ module Onfido
 
       raise ConnectionError.new(full_message)
     end
+
+    def validate_file!(file)
+      return if file.respond_to?(:read) && file.respond_to?(:path)
+
+      raise ArgumentError, "File must be a `File`-like object which responds to " \
+                           "`#read` and `#path`"
+    end
   end
 end

--- a/lib/onfido/resources/document.rb
+++ b/lib/onfido/resources/document.rb
@@ -3,7 +3,8 @@ module Onfido
     # with open-uri the file can be a link or an actual file
 
     def create(applicant_id, payload)
-      payload[:file] = open(payload.fetch(:file), 'r')
+      validate_file!(payload.fetch(:file))
+
       post(
         url: url_for("applicants/#{applicant_id}/documents"),
         payload: payload

--- a/lib/onfido/resources/live_photo.rb
+++ b/lib/onfido/resources/live_photo.rb
@@ -3,8 +3,9 @@ module Onfido
     # with open-uri the file can be a link or an actual file
 
     def create(applicant_id, payload)
+      validate_file!(payload.fetch(:file))
       payload[:applicant_id] = applicant_id
-      payload[:file] = open(payload.fetch(:file), 'r')
+
       post(
         url: url_for("/live_photos"),
         payload: payload

--- a/spec/integrations/document_spec.rb
+++ b/spec/integrations/document_spec.rb
@@ -4,13 +4,6 @@ describe Onfido::Document do
   subject(:document) { described_class.new }
 
   describe '#create' do
-    after do
-      file.close
-      file.unlink
-    end
-
-    let(:file) { Tempfile.new(['passport', '.jpg']) }
-    before { allow(document).to receive(:open).and_return(:file) }
     let(:params) do
       {
         type: 'passport',
@@ -20,9 +13,27 @@ describe Onfido::Document do
     end
     let(:applicant_id) { '1030303-123123-123123' }
 
-    it 'creates a new document' do
-      response = document.create('foobar', params)
-      expect(response['id']).not_to be_nil
+    context 'with a File-like object to upload' do
+      let(:file) { Tempfile.new(['passport', '.jpg']) }
+
+      after do
+        file.close
+        file.unlink
+      end
+
+      it 'creates a new document' do
+        response = document.create('foobar', params)
+        expect(response['id']).not_to be_nil
+      end
+    end
+
+    context 'passing in a non-File-like file to upload' do
+      let(:file) { 'https://onfido.com/images/logo.png' }
+
+      it 'raises an ArgumentError' do
+        expect { document.create('foobar', params) }.
+          to raise_error(ArgumentError, /must be a `File`-like object/)
+      end
     end
   end
 

--- a/spec/integrations/live_photo_spec.rb
+++ b/spec/integrations/live_photo_spec.rb
@@ -4,19 +4,29 @@ describe Onfido::LivePhoto do
   subject(:live_photo) { described_class.new }
 
   describe '#create' do
-    after do
-      file.close
-      file.unlink
+    let(:params) { { file: file } }
+
+    context 'with a File-like object to upload' do
+      let(:file) { Tempfile.new(['passport', '.jpg']) }
+
+      after do
+        file.close
+        file.unlink
+      end
+
+      it 'creates a new photo' do
+        response = live_photo.create('foobar', params)
+        expect(response['id']).not_to be_nil
+      end
     end
 
-    let(:file) { Tempfile.new(['photo', '.jpg']) }
-    before { allow(live_photo).to receive(:open).and_return(:file) }
-    let(:params) { { file: file } }
-    let(:applicant_id) { '1030303-123123-123123' }
+    context 'passing in a non-File-like file to upload' do
+      let(:file) { 'https://onfido.com/images/photo.jpg' }
 
-    it 'creates a new photo' do
-      response = live_photo.create('foobar', params)
-      expect(response['id']).not_to be_nil
+      it 'raises an ArgumentError' do
+        expect { live_photo.create('foobar', params) }.
+          to raise_error(ArgumentError, /must be a `File`-like object/)
+      end
     end
   end
 end


### PR DESCRIPTION
The gem is currently designed to allow providing a file to upload when creating a Document or Live Photo in the form of a `File`-like object or a URL to a file accessible over HTTP. If the latter is provided, it is fetched over HTTP and put into the payload for the `POST` request.

However, this functionality as it is currently implemented represents a security risk, as using `Kernel#open` (monkey-patched by `open-uri`) can potentially allow executing arbitrary commands on the server.

This takes the route of deprecating support for passing in URLs. We will raise an `ArgumentError` with an informative message if a non-`File` like object is provided (it should respond to `#read` and `#path`).

We could of course continue to support the existing behaviour, but:

* It seems perfectly reasonable to expect the caller to safely fetch the image themselves, and that way, they can do things like validate its content type, check the URL actually resolves, etc.
* It is actually quite difficult! I spent a fair bit of time investigating and we would have to re-invent the wheel quite a lot (e.g. `RestClient` has functionality which allows you to get a `Tempfile` for a response, but it has the wrong `#content_type` set ([1][1]) which ends up making the whole thing a big faff).

[1]: https://github.com/rest-client/rest-client/blob/c2e11b943a8514a94a2b7e68cb0f213cef06a6cc/lib/restclient/request.rb#L783