### PR TITLE
v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.9.0, 8 March 2018
+
+- Remove the ability to create Documents and Live Photos from a remote URL or local path, mitigating a potential security vulnerability (see #45 for details) (@timrogers)
+- Drop support for Ruby versions earlier than 2.2.0, since they have [reached end-of-life](https://www.ruby-lang.org/en/news/2017/04/01/support-of-ruby-2-1-has-ended/) (@timrogers)
+
 ## v0.8.4, 29 January 2018
 
 - Replace use of `method_missing` with explicitly-defined accessors when accessing

--- a/README.md
+++ b/README.md
@@ -12,8 +12,10 @@ This gem supports both `v1` and `v2` of the Onfido API. Refer to Onfido's [API d
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'onfido', '~> 0.8.4'
+gem 'onfido', '~> 0.9.0'
 ```
+
+The gem is compatible with Ruby 2.2.0 and onwards. Earlier versions of Ruby have [reached end-of-life](https://www.ruby-lang.org/en/news/2017/04/01/support-of-ruby-2-1-has-ended/), are no longer supported and no longer receive security fixes.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -73,8 +73,9 @@ api.document.all('applicant_id') # => Returns all applicant's documents
 ```
 
 **Note:** The file parameter must be a `File`-like object which responds to `#read` and `#path`.
-Previous versions of this gem supported providing a URL to a file accessible over PHP. You
-should fetch the file yourself and then pass it in to `#create`.
+Previous versions of this gem supported providing a URL to a file accessible over HTTP or a path
+to a file in the local filesystem. You should instead load the file yourself and then pass it in
+to `#create`.
 
 #### Live Photos
 
@@ -86,8 +87,9 @@ api.live_photo.create('applicant_id', file: 'http://example.com')
 ```
 
 **Note:** The file parameter must be a `File`-like object which responds to `#read` and `#path`.
-Previous versions of this gem supported providing a URL to a file accessible over PHP. You
-should fetch the file yourself and then pass it in to `#create`.
+Previous versions of this gem supported providing a URL to a file accessible over HTTP or a path
+to a file in the local filesystem. You should instead load the file yourself and then pass it in
+to `#create`.
 
 #### Checks
 

--- a/lib/onfido/version.rb
+++ b/lib/onfido/version.rb
@@ -1,3 +1,3 @@
 module Onfido
-  VERSION = '0.8.4'.freeze
+  VERSION = '0.9.0'.freeze
 end


### PR DESCRIPTION
- Remove the ability to create Documents and Live Photos from a remote URL or local path, mitigating a potential security vulnerability (see #45 for details) (@timrogers)
- Drop support for Ruby versions earlier than 2.2.0, since they have [reached end-of-life](https://www.ruby-lang.org/en/news/2017/04/01/support-of-ruby-2-1-has-ended/) (@timrogers)