### PR TITLE
Add token-dependant region-specific api endpoint

### DIFF
--- a/lib/onfido/configuration.rb
+++ b/lib/onfido/configuration.rb
@@ -31,17 +31,13 @@ module Onfido
     end
 
     def region
+      return unless api_key
+
       first_bit = api_key.split("_")[0]
 
-      case first_bit
-      when "live", "test" # it's an old, regionless api-token
-        nil
-      else # it's a new token the first bit being the region
-        first_bit
-      end
+      return if %w(live test).include?(first_bit)
 
-    rescue
-      nil
+      first_bit
     end
 
     def endpoint

--- a/lib/onfido/configuration.rb
+++ b/lib/onfido/configuration.rb
@@ -30,8 +30,26 @@ module Onfido
       RestClient.log ||= NullLogger.new
     end
 
+    def region
+      first_bit = api_key.split("_")[0]
+
+      case first_bit
+      when "live", "test" # it's an old, regionless api-token
+        nil
+      else # it's a new token the first bit being the region
+        first_bit
+      end
+
+    rescue
+      nil
+    end
+
     def endpoint
-      "https://api.onfido.com/#{api_version}/"
+      if region
+        "https://api.#{region}.onfido.com/#{api_version}/"
+      else
+        "https://api.onfido.com/#{api_version}/"
+      end
     end
   end
 end

--- a/spec/onfido_spec.rb
+++ b/spec/onfido_spec.rb
@@ -35,6 +35,27 @@ describe Onfido do
       end
     end
 
+    describe 'using a US API token' do
+      it 'should change endpoint' do
+        onfido.api_key = "us_live_asdfghjkl1234567890qwertyuiop"
+        expect(onfido.endpoint).to eq('https://api.us.onfido.com/v2/')
+      end
+    end
+
+    describe 'using a EU API token' do
+      it 'should change endpoint' do
+        onfido.api_key = "eu_live_asdfghjkl1234567890qwertyuiop"
+        expect(onfido.endpoint).to eq('https://api.eu.onfido.com/v2/')
+      end
+    end
+
+    describe 'using an old API token' do
+      it 'should use old endpoint' do
+        onfido.api_key = "live_asdfghjkl1234567890qwertyuiop"
+        expect(onfido.endpoint).to eq('https://api.onfido.com/v2/')
+      end
+    end
+
     describe '.logger' do
       context 'when an option is passed' do
         context 'when the option passed behaves like a logger' do


### PR DESCRIPTION
Added region to configuration, which is derived from the api_key and is then used to setup the api endpoint