### PR TITLE
Adding Check#find_by_url method

### DIFF
--- a/lib/onfido/resources/check.rb
+++ b/lib/onfido/resources/check.rb
@@ -13,6 +13,12 @@ module Onfido
                        "#{querystring}"))
     end
 
+    def find_by_url(url, expand: nil)
+      url_path = url.sub(/^https\:\/\/api\.onfido\.com\/v2\//,'')
+      querystring = "&expand=#{expand}" if expand
+      get(url: url_for("#{url_path}?#{querystring}")) 
+    end
+
     def all(applicant_id, page: 1, per_page: 20, expand: nil)
       querystring = "page=#{page}&per_page=#{per_page}"
       querystring += "&expand=#{expand}" if expand

--- a/spec/integrations/check_spec.rb
+++ b/spec/integrations/check_spec.rb
@@ -30,6 +30,48 @@ describe Onfido::Check do
     end
   end
 
+  describe '#find_by_url' do
+    let(:check_id) { '8546921-123123-123123' }
+
+    context 'partial url' do
+      let(:url) { "applicants/#{applicant_id}/checks/#{check_id}" }
+      
+      it 'returns an existing check for the applicant with the partial url' do
+        response = check.find_by_url(url)
+        expect(response['id']).to eq(check_id)
+      end
+
+      it "returns unexpanded reports" do
+        response = check.find_by_url(url)
+        expect(response['reports'].first).to be_a(String)
+      end
+
+      it 'allows you to expand the reports' do
+        response = check.find_by_url(url, expand: "reports")
+        expect(response['reports'].first).to be_a(Hash)
+      end
+    end
+
+    context 'full url' do
+      let(:url) { "https://api.onfido.com/v2/applicants/#{applicant_id}/checks/#{check_id}" }
+
+      it 'returns an existing check for the applicant with the partial url' do
+        response = check.find_by_url(url)
+        expect(response['id']).to eq(check_id)
+      end
+
+      it "returns unexpanded reports" do
+        response = check.find_by_url(url)
+        expect(response['reports'].first).to be_a(String)
+      end
+
+      it 'allows you to expand the reports' do
+        response = check.find_by_url(url, expand: "reports")
+        expect(response['reports'].first).to be_a(Hash)
+      end
+    end
+  end
+
   describe '#all' do
     let(:check_id) { '8546921-123123-123123' }
 


### PR DESCRIPTION
# The Problem

The Onfido Retrieve Check Endpoint requires _both_ the `applicant_id` and the `check_id` in order to retrieve a check instance.

Unfortunately, in the Onfido check webhook response it only includes the `check_id` as a property and it is missing the `applicant_id`:

    {
        "payload": {
             "resource_type":"check",
             "action":"check.completed",
             "object": {
                 "id":"5e97140e-fe9c-4b6d-bb31-8a1ccbe2faa9",
                 "status":"complete",
                 "completed_at":"2018-06-14 20:03:40 UTC",
                 "href":"https://api.onfido.com/v2/applicants/899fcd0c-0078-4181-93eb-db9f7f297d3a/checks/5e97140e-fe9c-4b6d-bb31-8a1ccbe2faa9"
             }
         }
    }

## Proposed Solution

The `payload.object.href` in the webhook request includes the fully qualified URL in order to retrieve the check. So, it would be easiest for the implementor to pass this URL to the gem as `api.check.get_by_url(request['payload']['object']['href'])` instead of looking up the applicant from their own database.

The `Onfido::Check#find_by_url` accepts _both_ the partially qualified URL path and the fully qualified URL path. 

## Example

This example is in Rails flavor:

    api = Onfido::API.new(api_key: 'YOUR API KEY HERE')
    check = api.check.find_by_url(params[:payload][:object][:href])




