### PR TITLE
Region support

### DIFF
--- a/lib/onfido/version.rb
+++ b/lib/onfido/version.rb
@@ -1,3 +1,3 @@
 module Onfido
-  VERSION = '0.12.0'.freeze
+  VERSION = '0.13.0'.freeze
 end

--- a/spec/onfido_spec.rb
+++ b/spec/onfido_spec.rb
@@ -35,17 +35,18 @@ describe Onfido do
       end
     end
 
-    describe 'using a US API token' do
+    describe 'using the US region' do
       it 'should change endpoint' do
-        onfido.api_key = "us_live_asdfghjkl1234567890qwertyuiop"
+        onfido.region = 'us'
         expect(onfido.endpoint).to eq('https://api.us.onfido.com/v2/')
       end
     end
 
-    describe 'using a EU API token' do
+    describe 'using an unsupported region' do
       it 'should change endpoint' do
-        onfido.api_key = "eu_live_asdfghjkl1234567890qwertyuiop"
-        expect(onfido.endpoint).to eq('https://api.eu.onfido.com/v2/')
+        onfido.region = 'de'
+        expect { onfido.endpoint }.
+          to raise_error('The region "de" is not currently supported')
       end
     end
 


### PR DESCRIPTION
(for any Onfido employees, you can see [the internal ticket here](https://jira.onfido.co.uk/browse/EG-3600))

Currently this library auto-detects the library depending on the token passed in. This is fine, but to avoid possible breaking changes if we ever want to change our token format (there is no such planned change, but just to minimise risk), we want to remove any dependency on the token format.

This doesn't need to be a breaking change, since there shouldn't be anyone using this implicit token→region logic in production at the moment.