### PR TITLE
Extend config with webhook_token

### DIFF
--- a/lib/onfido/configuration.rb
+++ b/lib/onfido/configuration.rb
@@ -4,7 +4,8 @@ module Onfido
       us: "api.us.onfido.com"
     }.freeze
 
-    attr_accessor :api_key, :region, :open_timeout, :read_timeout, :api_version
+    attr_accessor :api_key, :region, :open_timeout, :read_timeout, :api_version,
+                  :webhook_token
 
     def self.extended(base)
       base.reset
@@ -16,6 +17,7 @@ module Onfido
 
     def reset
       self.api_key = nil
+      self.webhook_token = nil
       self.region = nil
       self.open_timeout = 30
       self.read_timeout = 80

--- a/lib/onfido/resources/webhook.rb
+++ b/lib/onfido/resources/webhook.rb
@@ -18,7 +18,7 @@ module Onfido
     # As well as being a normal resource, Onfido::Webhook also supports
     # verifying the authenticity of a webhook by comparing the signature on the
     # request to one computed from the body
-    def self.valid?(request_body, request_signature, token)
+    def self.valid?(request_body, request_signature, token = Onfido.webhook_token)
       if [request_body, request_signature, token].any?(&:nil?)
         raise ArgumentError, "A request body, request signature and token " \
                              "must be provided"


### PR DESCRIPTION
Since `Onfido.api_key` is a thing, it would be nice that `Onfido.webhook_token` would exist too. 

Note: Intentionally left the PR without tests, want to see if the idea is ok.